### PR TITLE
Cancel subscription

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -6,6 +6,12 @@ class Api::V1::SubscriptionsController < ApplicationController
     end
   end
 
+  def update
+    subscription = Subscription.find(params[:id])
+    subscription.update(status: 1)
+    render json: SubscriptionSerializer.subscription_json(subscription)
+  end
+
   def subscription_params
     params.permit(:tea_id, :customer_id, :title, :status, :frequency, :box_quantity)
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       post 'customers/:id/subscriptions', to: 'subscriptions#create'
+      patch 'customers/:id/subscriptions/:id', to: 'subscriptions#update'
     end
   end
 end

--- a/spec/requests/api/v1/cancel_subscription_request_spec.rb
+++ b/spec/requests/api/v1/cancel_subscription_request_spec.rb
@@ -1,7 +1,7 @@
 require 'rails_helper'
 
-RSpec.describe 'Create Subscription Request' do
-  it 'can  customer subscription' do
+RSpec.describe 'Cancel Subscription Request' do
+  it 'can cancel a customer subscription' do
     customer_1 = Customer.create!(first_name: "Kerri", last_name: "Hoffmann", email: "kerri@yahoo.com", address: "123 Main St, Denver, CO 80210")
     tea_1 = Tea.create!(name: "Starry Night", description: "Night time tea", temperature: 90, brew_time: 5, price: 3.50)
     tea_2 = Tea.create!(name: "Wakey Wakey", description: "Green tea", temperature: 90, brew_time: 5, price: 3.50)
@@ -10,13 +10,15 @@ RSpec.describe 'Create Subscription Request' do
 
     patch "/api/v1/customers/#{customer_1.id}/subscriptions/#{subscription_1.id}", params: subscription_1, as: :json
 
-    updated_subscription = (Subscription.find(subscription_1.id))
-    updated_subscription[:status].to eq("cancelled")
+    updated_subscription = Subscription.find(subscription_1.id)
+    active_subscription = Subscription.find(subscription_2.id)
+    expect(updated_subscription[:status]).to eq("cancelled")
+    expect(active_subscription[:status]).to eq("active")
 
     parsed_response = JSON.parse(response.body, symbolize_names: true)
 
     expect(response).to be_successful
-    expect(response.status).to eq(201)
+    expect(response.status).to eq(200)
 
     expect(parsed_response).to be_a(Hash)
     expect(parsed_response[:data][:type]).to eq("subscriptions")

--- a/spec/requests/api/v1/cancel_subscription_request_spec.rb
+++ b/spec/requests/api/v1/cancel_subscription_request_spec.rb
@@ -1,0 +1,31 @@
+require 'rails_helper'
+
+RSpec.describe 'Create Subscription Request' do
+  it 'can  customer subscription' do
+    customer_1 = Customer.create!(first_name: "Kerri", last_name: "Hoffmann", email: "kerri@yahoo.com", address: "123 Main St, Denver, CO 80210")
+    tea_1 = Tea.create!(name: "Starry Night", description: "Night time tea", temperature: 90, brew_time: 5, price: 3.50)
+    tea_2 = Tea.create!(name: "Wakey Wakey", description: "Green tea", temperature: 90, brew_time: 5, price: 3.50)
+    subscription_1 = Subscription.create!(tea_id: tea_1.id, customer_id: customer_1.id, title: tea_1.name, status: 0, frequency: 4, box_quantity: 1)
+    subscription_2 = Subscription.create!(tea_id: tea_2.id, customer_id: customer_1.id, title: tea_2.name, status: 0, frequency: 4, box_quantity: 1)
+
+    patch "/api/v1/customers/#{customer_1.id}/subscriptions/#{subscription_1.id}", params: subscription_1, as: :json
+
+    updated_subscription = (Subscription.find(subscription_1.id))
+    updated_subscription[:status].to eq("cancelled")
+
+    parsed_response = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to be_successful
+    expect(response.status).to eq(201)
+
+    expect(parsed_response).to be_a(Hash)
+    expect(parsed_response[:data][:type]).to eq("subscriptions")
+    expect(parsed_response[:data]).to have_key(:id)
+    expect(parsed_response[:data][:attributes][:customer_id]).to eq(customer_1.id)
+    expect(parsed_response[:data][:attributes][:tea_id]).to eq(tea_1.id)
+    expect(parsed_response[:data][:attributes][:title]).to eq("Starry Night")
+    expect(parsed_response[:data][:attributes][:status]).to eq("cancelled")
+    expect(parsed_response[:data][:attributes][:frequency]).to eq(4)
+    expect(parsed_response[:data][:attributes][:box_quantity]).to eq(1)
+  end
+end


### PR DESCRIPTION
Add request spec, patch route, and update action to Subscriptions controller to 'cancel' a subscription.  Cancelling is changing the status column of the Subscription for active to cancelled. 