### PR TITLE
Add expectations

### DIFF
--- a/spec/requests/api/v1/cancel_subscription_request_spec.rb
+++ b/spec/requests/api/v1/cancel_subscription_request_spec.rb
@@ -29,5 +29,6 @@ RSpec.describe 'Cancel Subscription Request' do
     expect(parsed_response[:data][:attributes][:status]).to eq("cancelled")
     expect(parsed_response[:data][:attributes][:frequency]).to eq(4)
     expect(parsed_response[:data][:attributes][:box_quantity]).to eq(1)
+    expect(parsed_response[:data][:attributes][:title]).to_not eq("Wakey Wakey")
   end
 end

--- a/spec/requests/api/v1/create_subscription_request_spec.rb
+++ b/spec/requests/api/v1/create_subscription_request_spec.rb
@@ -5,6 +5,9 @@ RSpec.describe 'Create Subscription Request' do
     customer_1 = Customer.create!(first_name: "Kerri", last_name: "Hoffmann", email: "kerri@yahoo.com", address: "123 Main St, Denver, CO 80210")
     tea_1 = Tea.create!(name: "Starry Night", description: "Night time tea", temperature: 90, brew_time: 5, price: 3.50)
 
+    customer_2 = Customer.create!(first_name: "Rob", last_name: "Katnich", email: "rob@gmail.com", address: "123 Main St, Denver, CO 80210")
+    tea_2 = Tea.create!(name: "Starry Night", description: "Night time tea", temperature: 90, brew_time: 5, price: 3.50)
+
     subscription_1 = {
                         "tea_id": "#{tea_1.id}",
                         "customer_id": "#{customer_1.id}",
@@ -32,5 +35,6 @@ RSpec.describe 'Create Subscription Request' do
     expect(parsed_response[:data][:attributes][:status]).to eq("active")
     expect(parsed_response[:data][:attributes][:frequency]).to eq(4)
     expect(parsed_response[:data][:attributes][:box_quantity]).to eq(1)
+    expect(parsed_response[:data][:attributes][:customer_id]).to_not eq(customer_2.id)
   end
 end


### PR DESCRIPTION
Add expectations to cancel_subscription_request_spec and create_subscription_request_spec to make sure only certain subscriptions are targeted and certain attributes do not match that of other customers or subscriptions.