### PR TITLE
Error for creating tea subscription with incorrect box quantity or frequency

### DIFF
--- a/app/controllers/api/v1/subscriptions_controller.rb
+++ b/app/controllers/api/v1/subscriptions_controller.rb
@@ -3,6 +3,8 @@ class Api::V1::SubscriptionsController < ApplicationController
     subscription = Subscription.create(subscription_params)
     if subscription.save
       render json: SubscriptionSerializer.subscription_json(subscription), status: 201
+    else
+      render json: { errors: subscription.errors.full_messages }, status: 400
     end
   end
 

--- a/app/models/subscription.rb
+++ b/app/models/subscription.rb
@@ -6,6 +6,8 @@ class Subscription < ApplicationRecord
   validates_presence_of :title
   validates_presence_of :status
   validates_presence_of :frequency
+  validates_numericality_of :frequency, greater_than_or_equal_to: 1
   validates_presence_of :box_quantity
+  validates_numericality_of :box_quantity, greater_than_or_equal_to: 1
   enum status: {active: 0, cancelled: 1}
 end

--- a/spec/models/subscription_spec.rb
+++ b/spec/models/subscription_spec.rb
@@ -10,4 +10,6 @@ RSpec.describe Subscription, type: :model do
   it { should validate_presence_of :status }
   it { should validate_presence_of :frequency }
   it { should validate_presence_of :box_quantity }
+  it { should validate_numericality_of(:box_quantity).is_greater_than_or_equal_to(1) }
+  it { should validate_numericality_of(:frequency).is_greater_than_or_equal_to(1) }
 end

--- a/spec/requests/api/v1/create_subscription_request_spec.rb
+++ b/spec/requests/api/v1/create_subscription_request_spec.rb
@@ -33,4 +33,26 @@ RSpec.describe 'Create Subscription Request' do
     expect(parsed_response[:data][:attributes][:frequency]).to eq(4)
     expect(parsed_response[:data][:attributes][:box_quantity]).to eq(1)
   end
+
+  it 'shows an error if the box_quantity is less than 1' do
+    customer_1 = Customer.create!(first_name: "Kerri", last_name: "Hoffmann", email: "kerri@yahoo.com", address: "123 Main St, Denver, CO 80210")
+    tea_1 = Tea.create!(name: "Starry Night", description: "Night time tea", temperature: 90, brew_time: 5, price: 3.50)
+
+    subscription_1 = {
+                        "tea_id": "#{tea_1.id}",
+                        "customer_id": "#{customer_1.id}",
+                        "title": "#{tea_1.name}",
+                        "status": "active",
+                        "frequency": "4",
+                        "box_quantity": "0",
+                      }
+
+    post "/api/v1/customers/#{customer_1.id}/subscriptions", params: subscription_1, as: :json
+
+    parsed_response = JSON.parse(response.body, symbolize_names: true)
+
+    expect(response).to_not be_successful
+    expect(response.status).to eq(400)
+    expect(parsed_response[:errors][0]).to eq("Box quantity must be greater than or equal to 1")
+  end
 end


### PR DESCRIPTION
Add Subscription model validations with test that box quantity and frequency must be greater than or equal to 1.
Add logic for error handling in Subscription controller create action.